### PR TITLE
Fix Vercel deployment build errors

### DIFF
--- a/.vercelignore
+++ b/.vercelignore
@@ -1,5 +1,4 @@
 
 server/
 node_modules/
-dist/
 .replit

--- a/client/src/components/sections/CleanKitchenToolkit.tsx
+++ b/client/src/components/sections/CleanKitchenToolkit.tsx
@@ -101,7 +101,6 @@ const CleanKitchenToolkit = () => {
                 <motion.div
                   className={`w-24 h-24 rounded-full bg-gradient-to-r ${tool.color} flex items-center justify-center mb-6`}
                   whileHover={{ scale: 1.1, rotate: 360 }}
-                  transition={{ duration: 0.6 }}
                   initial={{ opacity: 0, scale: 0.8 }}
                   whileInView={{ opacity: 1, scale: 1 }}
                   transition={{ duration: 0.5, delay: 1.0 + index * 0.2 }}
@@ -153,7 +152,6 @@ const CleanKitchenToolkit = () => {
                 <motion.div
                   className="w-64 h-64 bg-white rounded-2xl shadow-2xl flex items-center justify-center border-2 border-gray-200"
                   whileHover={{ scale: 1.05 }}
-                  transition={{ duration: 0.3 }}
                   initial={{ opacity: 0, scale: 0.8 }}
                   whileInView={{ opacity: 1, scale: 1 }}
                   transition={{ duration: 0.5, delay: 1.4 + index * 0.2 }}

--- a/client/src/components/sections/WealthEngines.tsx
+++ b/client/src/components/sections/WealthEngines.tsx
@@ -111,7 +111,6 @@ const WealthEngines = () => {
                   <motion.div
                     className={`w-20 h-20 mx-auto mb-6 rounded-full bg-gradient-to-r ${engine.color} flex items-center justify-center group-hover:scale-110 transition-transform duration-300`}
                     whileHover={{ rotate: 360 }}
-                    transition={{ duration: 0.6 }}
                     initial={{ opacity: 0, scale: 0.8 }}
                     whileInView={{ opacity: 1, scale: 1 }}
                     transition={{ duration: 0.5, delay: 1.0 + index * 0.2 }}

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,19 @@
+{
+  "version": 2,
+  "builds": [
+    {
+      "src": "package.json",
+      "use": "@vercel/static-build",
+      "config": {
+        "distDir": "dist/public"
+      }
+    }
+  ],
+  "routes": [
+    {
+      "src": "/(.*)",
+      "dest": "/index.html"
+    }
+  ],
+  "buildCommand": "npm run build:static"
+}


### PR DESCRIPTION
Configure Vercel for static site deployment and fix duplicate JSX attribute errors.

The Vercel build was failing due to an esbuild error when trying to bundle the server entry point and duplicate `transition` attributes in JSX. This PR configures Vercel to deploy the project as a static site by using `@vercel/static-build` and removes the redundant JSX attributes, enabling successful deployment.

---
<a href="https://cursor.com/background-agent?bcId=bc-a8abdccd-6b57-4b11-9e43-40adfca9d325">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-a8abdccd-6b57-4b11-9e43-40adfca9d325">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>